### PR TITLE
fix: num_tokens all_reduce crash in DPO recipes

### DIFF
--- a/recipes/full_dpo_distributed.py
+++ b/recipes/full_dpo_distributed.py
@@ -905,7 +905,7 @@ class FullDPORecipeDistributed(FTRecipeInterface):
 
                 # batch is input_ids, labels
                 with self.activations_handling_ctx:
-                    num_tokens += batch[0].numel()
+                    num_tokens += torch.tensor(batch[0].numel())
                     (
                         policy_chosen_log_probs,
                         policy_rejected_log_probs,

--- a/recipes/lora_dpo_distributed.py
+++ b/recipes/lora_dpo_distributed.py
@@ -689,7 +689,7 @@ class LoRADPORecipeDistributed(FTRecipeInterface):
                     break
 
                 # batch is input_ids, labels
-                num_tokens += batch[0].numel()
+                num_tokens += torch.tensor(batch[0].numel())
 
                 (
                     policy_chosen_log_probs,


### PR DESCRIPTION
# TL;DR

Fixed a crash on `all_reduce(num_tokens)` because `num_tokens` wasn't a tensor.